### PR TITLE
Revert "Disable the `xdp_umem_reg` size check for now. (#1227)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = { version = "1.5.2", optional = true }
 [target.'cfg(all(not(rustix_use_libc), not(miri), target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"))))'.dependencies]
 linux-raw-sys = { version = "0.4.14", default-features = false, features = ["general", "errno", "ioctl", "no_std", "elf"] }
 libc_errno = { package = "errno", version = "0.3.8", default-features = false, optional = true }
-libc = { version = "0.2.161", default-features = false, optional = true }
+libc = { version = "0.2.167", default-features = false, optional = true }
 
 # Dependencies for platforms where only libc is supported:
 #
@@ -46,7 +46,7 @@ libc = { version = "0.2.161", default-features = false, optional = true }
 # backend, so enable its dependencies unconditionally.
 [target.'cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", target_arch = "s390x"), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))'.dependencies]
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
-libc = { version = "0.2.161", default-features = false }
+libc = { version = "0.2.167", default-features = false }
 
 # Additional dependencies for Linux with the libc backend:
 #
@@ -74,7 +74,7 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3.5.0"
-libc = "0.2.161"
+libc = "0.2.167"
 libc_errno = { package = "errno", version = "0.3.8", default-features = false }
 serial_test = "2.0.0"
 memoffset = "0.9.0"

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1658,7 +1658,7 @@ pub mod xdp {
     /// XDP umem registration.
     ///
     /// `struct xdp_umem_reg`
-    // https://github.com/torvalds/linux/blob/v6.6/include/uapi/linux/if_xdp.h#L73-L79
+    // https://github.com/torvalds/linux/blob/v6.8/include/uapi/linux/if_xdp.h#L79-L86
     #[repr(C)]
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub struct XdpUmemReg {
@@ -1674,6 +1674,10 @@ pub mod xdp {
         ///
         /// Requires kernel version 5.4.
         pub flags: XdpUmemRegFlags,
+        /// AF_XDP TX metadata length
+        ///
+        /// Requires kernel version 6.8.
+        pub tx_metadata_len: u32,
     }
 
     /// XDP statistics.

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1809,11 +1809,8 @@ fn test_sizes() {
     #[cfg(linux_kernel)]
     assert_eq_size!(UCred, libc::ucred);
 
-    // Linux added fields to `xdp_umem_reg` so it's bigger now.
-    /*
     #[cfg(target_os = "linux")]
     assert_eq_size!(super::xdp::XdpUmemReg, c::xdp_umem_reg);
-    */
     #[cfg(target_os = "linux")]
     assert_eq_size!(super::xdp::XdpOptions, c::xdp_options);
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
This reverts commit e38d2af27bf6ba6070d16d5b00ab3067f66f4444.